### PR TITLE
Index performance

### DIFF
--- a/R/slide-between-common.R
+++ b/R/slide-between-common.R
@@ -20,15 +20,15 @@ slide_between_common <- function(x,
   check_not_na(stops, "`.stops`")
   check_ascending(stops, "`.stops`")
 
-  out_size <- vec_size_common(starts, stops)
+  size <- vec_size_common(starts, stops)
 
-  args <- vec_recycle_common(starts, stops, .size = out_size)
+  args <- vec_recycle_common(starts, stops, .size = size)
   args <- vec_cast_common(i, !!!args)
   args <- lapply(args, vec_proxy_compare)
 
   # Early exit if empty input
   # (but after all size checks have been done)
-  if (out_size == 0L) {
+  if (size == 0L) {
     return(vec_init(ptype, 0L))
   }
 
@@ -40,12 +40,6 @@ slide_between_common <- function(x,
   i <- split$key
   window_indices <- split$pos
 
-  params <- list(
-    type,
-    constrain,
-    out_size
-  )
-
   .Call(
     slide_between_common_impl,
     x,
@@ -56,6 +50,8 @@ slide_between_common <- function(x,
     ptype,
     env,
     window_indices,
-    params
+    type,
+    constrain,
+    size
   )
 }

--- a/R/slide-index-common.R
+++ b/R/slide-index-common.R
@@ -31,7 +31,6 @@ slide_index_common <- function(x,
   i <- split$key
 
   # `indices` helps us map back to `.x`
-  # For `slide_index()` this is both `out_indices` and `window_indices`
   indices <- split$pos
 
   range <- compute_ranges(i, before, after)

--- a/R/slide-index-common.R
+++ b/R/slide-index-common.R
@@ -10,15 +10,15 @@ slide_index_common <- function(x,
                                type) {
   vec_assert(i)
 
-  out_size <- compute_size(x, type)
+  size <- compute_size(x, type)
 
-  check_index_size(out_size, i)
+  check_index_size(size, i)
   check_not_na(i, "`.i`")
   check_ascending(i, "The `.i`ndex")
 
   # Early exit if empty input
   # (but after the index size check)
-  if (out_size == 0L) {
+  if (size == 0L) {
     return(vec_init(ptype, 0L))
   }
 
@@ -39,13 +39,6 @@ slide_index_common <- function(x,
   starts <- range$starts
   stops <- range$stops
 
-  params <- list(
-    type,
-    constrain,
-    complete,
-    out_size
-  )
-
   .Call(
     slide_index_common_impl,
     x,
@@ -56,7 +49,10 @@ slide_index_common <- function(x,
     ptype,
     env,
     indices,
-    params
+    type,
+    constrain,
+    size,
+    complete
   )
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -5,7 +5,7 @@
 
 /* .Call calls */
 extern SEXP slide_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP slide_between_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP slide_between_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP slide_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 
 // Defined below
@@ -13,7 +13,7 @@ SEXP slide_init(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"slide_common_impl",         (DL_FUNC) &slide_common_impl, 5},
-  {"slide_between_common_impl", (DL_FUNC) &slide_between_common_impl, 9},
+  {"slide_between_common_impl", (DL_FUNC) &slide_between_common_impl, 11},
   {"slide_index_common_impl",   (DL_FUNC) &slide_index_common_impl, 9},
   {"slide_init",                (DL_FUNC) &slide_init, 1},
   {NULL, NULL, 0}

--- a/src/init.c
+++ b/src/init.c
@@ -6,7 +6,7 @@
 /* .Call calls */
 extern SEXP slide_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP slide_between_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP slide_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP slide_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 
 // Defined below
 SEXP slide_init(SEXP);
@@ -14,7 +14,7 @@ SEXP slide_init(SEXP);
 static const R_CallMethodDef CallEntries[] = {
   {"slide_common_impl",         (DL_FUNC) &slide_common_impl, 5},
   {"slide_between_common_impl", (DL_FUNC) &slide_between_common_impl, 11},
-  {"slide_index_common_impl",   (DL_FUNC) &slide_index_common_impl, 9},
+  {"slide_index_common_impl",   (DL_FUNC) &slide_index_common_impl, 12},
   {"slide_init",                (DL_FUNC) &slide_init, 1},
   {NULL, NULL, 0}
 };

--- a/src/slide-between.c
+++ b/src/slide-between.c
@@ -205,7 +205,7 @@ static struct index_info new_index_info(SEXP i) {
 
 static void check_starts_not_past_stops(SEXP starts, SEXP stops);
 
-static struct range_info new_range_info(SEXP starts, SEXP stops, int count) {
+static struct range_info new_range_info(SEXP starts, SEXP stops, int size) {
   struct range_info range;
 
   range.starts = starts;
@@ -221,7 +221,7 @@ static struct range_info new_range_info(SEXP starts, SEXP stops, int count) {
     check_starts_not_past_stops(starts, stops);
   }
 
-  range.count = count;
+  range.size = size;
 
   return range;
 }
@@ -256,21 +256,21 @@ static struct iteration_info new_iteration_info(struct index_info index, struct 
   struct iteration_info iteration;
 
   int iteration_min = 1;
-  int iteration_max = range.count;
+  int iteration_max = range.size;
 
   if (complete) {
     if (!range.start_unbounded) {
-      iteration_min += iteration_min_adjustment(index, range.starts, range.count);
+      iteration_min += iteration_min_adjustment(index, range.starts, range.size);
     }
     if (!range.stop_unbounded) {
-      iteration_max -= iteration_max_adjustment(index, range.stops, range.count);
+      iteration_max -= iteration_max_adjustment(index, range.stops, range.size);
     }
   } else {
     if (!range.start_unbounded) {
-      iteration_max -= iteration_max_adjustment(index, range.starts, range.count);
+      iteration_max -= iteration_max_adjustment(index, range.starts, range.size);
     }
     if (!range.stop_unbounded) {
-      iteration_min += iteration_min_adjustment(index, range.stops, range.count);
+      iteration_min += iteration_min_adjustment(index, range.stops, range.size);
     }
   }
 

--- a/src/slide-between.c
+++ b/src/slide-between.c
@@ -21,6 +21,7 @@ static struct iteration_info new_iteration_info(struct index_info, struct range_
 static void eval_loop(SEXP,
                       SEXP,
                       SEXP,
+                      SEXP,
                       struct out_info,
                       struct index_info,
                       struct window_info,
@@ -68,9 +69,9 @@ SEXP slide_index_common_impl(SEXP x,
   struct out_info out = new_out_info(ptype, indices, out_size);
   PROTECT_OUT_INFO(&out, &n_prot);
 
-  eval_loop(x, env, f_call, out, index, window, range, type, constrain, complete);
+  eval_loop(x, env, f_call, ptype, out, index, window, range, type, constrain, complete);
 
-  out.data = vec_restore(out.data, out.ptype, r_int(out.size));
+  out.data = vec_restore(out.data, ptype, r_int(out.size));
   PROTECT_N(out.data, &n_prot);
 
   out.data = copy_names(out.data, x, type);
@@ -125,9 +126,9 @@ SEXP slide_between_common_impl(SEXP x,
   struct out_info out = new_out_info(ptype, out_indices, out_size);
   PROTECT_OUT_INFO(&out, &n_prot);
 
-  eval_loop(x, env, f_call, out, index, window, range, type, constrain, complete);
+  eval_loop(x, env, f_call, ptype, out, index, window, range, type, constrain, complete);
 
-  out.data = vec_restore(out.data, out.ptype, r_int(out.size));
+  out.data = vec_restore(out.data, ptype, r_int(out.size));
   PROTECT_N(out.data, &n_prot);
 
   out.data = copy_names(out.data, x, type);
@@ -145,7 +146,6 @@ static struct out_info new_out_info(SEXP ptype, SEXP indices, int size) {
   out.data = PROTECT(vec_init(ptype, size));
   out.data = PROTECT(vec_proxy(out.data));
 
-  out.ptype = ptype;
   out.size = size;
 
   out.indices = indices;
@@ -394,6 +394,7 @@ static void increment_window(struct window_info window,
 static void eval_loop(SEXP x,
                       SEXP env,
                       SEXP f_call,
+                      SEXP ptype,
                       struct out_info out,
                       struct index_info index,
                       struct window_info window,
@@ -445,7 +446,7 @@ static void eval_loop(SEXP x,
     // https://github.com/r-lib/vctrs/blob/8d12bfc0e29e056966e0549af619253253752a64/src/slice-assign.c#L46
 
     if (constrain) {
-      elt = vctrs_cast(elt, out.ptype, strings_empty, strings_empty);
+      elt = vctrs_cast(elt, ptype, strings_empty, strings_empty);
       REPROTECT(elt, elt_prot_idx);
       elt = vec_proxy(elt);
       REPROTECT(elt, elt_prot_idx);

--- a/src/slide-between.c
+++ b/src/slide-between.c
@@ -132,12 +132,14 @@ SEXP slide_between_common_impl(SEXP x,
                                SEXP ptype,
                                SEXP env,
                                SEXP window_indices,
-                               SEXP params) {
+                               SEXP type_,
+                               SEXP constrain_,
+                               SEXP size_) {
   int n_prot = 0;
 
-  int type = r_scalar_int_get(r_lst_get(params, 0));
-  bool constrain = r_scalar_lgl_get(r_lst_get(params, 1));
-  int out_size = r_scalar_int_get(r_lst_get(params, 2));
+  int type = r_scalar_int_get(type_);
+  bool constrain = r_scalar_lgl_get(constrain_);
+  int size = r_scalar_int_get(size_);
 
   int force = compute_force(type);
 
@@ -155,7 +157,7 @@ SEXP slide_between_common_impl(SEXP x,
   struct window_info window = new_window_info(window_starts, window_stops, index.size);
   PROTECT_WINDOW_INFO(&window, &n_prot);
 
-  struct range_info range = new_range_info(starts, stops, out_size);
+  struct range_info range = new_range_info(starts, stops, size);
   PROTECT_RANGE_INFO(&range, &n_prot);
 
   // `complete = false` for `slide_between()`
@@ -163,7 +165,7 @@ SEXP slide_between_common_impl(SEXP x,
 
   SEXP container = PROTECT_N(make_slice_container(type), &n_prot);
 
-  SEXP out = PROTECT_N(vec_init(ptype, out_size), &n_prot);
+  SEXP out = PROTECT_N(vec_init(ptype, size), &n_prot);
   out = PROTECT_N(vec_proxy(out), &n_prot);
 
   // 1 based index for `vec_assign()`
@@ -213,7 +215,7 @@ SEXP slide_between_common_impl(SEXP x,
     UNPROTECT(1);
   }
 
-  out = PROTECT_N(vec_restore(out, ptype, r_int(out_size)), &n_prot);
+  out = PROTECT_N(vec_restore(out, ptype, size_), &n_prot);
   out = PROTECT_N(copy_names(out, x, type), &n_prot);
 
   UNPROTECT(n_prot);

--- a/src/slide-between.c
+++ b/src/slide-between.c
@@ -192,14 +192,10 @@ static struct index_info new_index_info(SEXP i) {
   index.data = i;
   index.size = vec_size(i);
 
-  index.first = PROTECT(vec_slice_impl(i, r_int(1)));
-  index.last = PROTECT(vec_slice_impl(i, r_int(index.size)));
-
   index.compare_lt = get_compare_fn_lt(i);
   index.compare_gt = get_compare_fn_gt(i);
   index.compare_lte = get_compare_fn_lte(i);
 
-  UNPROTECT(2);
   return index;
 }
 
@@ -214,14 +210,14 @@ static struct last_info new_last_info(struct index_info index) {
   last.p_start_loc_val = INTEGER(last.start_loc);
   last.p_stop_loc_val = INTEGER(last.stop_loc);
 
-  last.start_index = index.first;
-  last.stop_index = index.first;
+  last.start_index = PROTECT(vec_slice_impl(index.data, r_int(1)));
+  last.stop_index = PROTECT(vec_slice_impl(index.data, r_int(1)));
 
   // last.p_start_index and last.p_stop_index are initialized
   // after last.start_index and last.stop_index have been protected
   // inside PROTECT_LAST_INFO
 
-  UNPROTECT(2);
+  UNPROTECT(4);
   return last;
 }
 
@@ -312,7 +308,7 @@ static int iteration_min_adjustment(struct index_info index, SEXP range, int siz
   int forward_adjustment = 0;
 
   for (int j = 0; j < size; ++j) {
-    if (index.compare_gt(index.first, 0, range, j)) {
+    if (index.compare_gt(index.data, 0, range, j)) {
       forward_adjustment++;
     } else {
       break;
@@ -326,7 +322,7 @@ static int iteration_max_adjustment(struct index_info index, SEXP range, int siz
   int backward_adjustment = 0;
 
   for (int j = size - 1; j >= 0; --j) {
-    if (index.compare_lt(index.last, 0, range, j)) {
+    if (index.compare_lt(index.data, index.size - 1, range, j)) {
       backward_adjustment++;
     } else {
       break;

--- a/src/slide-between.c
+++ b/src/slide-between.c
@@ -71,10 +71,10 @@ SEXP slide_index_common_impl(SEXP x,
   eval_loop(x, env, f_call, out, index, window, range, type, constrain, complete);
 
   out.data = vec_restore(out.data, out.ptype, r_int(out.size));
-  REPROTECT(out.data, out.data_pidx);
+  PROTECT_N(out.data, &n_prot);
 
   out.data = copy_names(out.data, x, type);
-  REPROTECT(out.data, out.data_pidx);
+  PROTECT_N(out.data, &n_prot);
 
   UNPROTECT(n_prot);
   return out.data;
@@ -128,10 +128,10 @@ SEXP slide_between_common_impl(SEXP x,
   eval_loop(x, env, f_call, out, index, window, range, type, constrain, complete);
 
   out.data = vec_restore(out.data, out.ptype, r_int(out.size));
-  REPROTECT(out.data, out.data_pidx);
+  PROTECT_N(out.data, &n_prot);
 
   out.data = copy_names(out.data, x, type);
-  REPROTECT(out.data, out.data_pidx);
+  PROTECT_N(out.data, &n_prot);
 
   UNPROTECT(n_prot);
   return out.data;

--- a/src/slide-between.c
+++ b/src/slide-between.c
@@ -306,9 +306,10 @@ static struct iteration_info new_iteration_info(struct index_info index, struct 
 
 static int iteration_min_adjustment(struct index_info index, SEXP range, int size) {
   int forward_adjustment = 0;
+  R_len_t index_first = 0;
 
   for (int j = 0; j < size; ++j) {
-    if (index.compare_gt(index.data, 0, range, j)) {
+    if (index.compare_gt(index.data, index_first, range, j)) {
       forward_adjustment++;
     } else {
       break;
@@ -320,9 +321,10 @@ static int iteration_min_adjustment(struct index_info index, SEXP range, int siz
 
 static int iteration_max_adjustment(struct index_info index, SEXP range, int size) {
   int backward_adjustment = 0;
+  R_len_t index_last = index.size - 1;
 
   for (int j = size - 1; j >= 0; --j) {
-    if (index.compare_lt(index.data, index.size - 1, range, j)) {
+    if (index.compare_lt(index.data, index_last, range, j)) {
       backward_adjustment++;
     } else {
       break;

--- a/src/slide-between.c
+++ b/src/slide-between.c
@@ -238,9 +238,7 @@ static void stop_range_start_past_stop(SEXP starts, SEXP stops) {
 }
 
 static void check_starts_not_past_stops(SEXP starts, SEXP stops) {
-  bool any_gt = vec_any_gt(starts, stops);
-
-  if (any_gt) {
+  if (vec_any_gt(starts, stops)) {
     stop_range_start_past_stop(starts, stops);
   }
 }

--- a/src/slide-between.c
+++ b/src/slide-between.c
@@ -33,13 +33,16 @@ SEXP slide_index_common_impl(SEXP x,
                              SEXP ptype,
                              SEXP env,
                              SEXP indices,
-                             SEXP params) {
+                             SEXP type_,
+                             SEXP constrain_,
+                             SEXP size_,
+                             SEXP complete_) {
   int n_prot = 0;
 
-  int type = r_scalar_int_get(r_lst_get(params, 0));
-  bool constrain = r_scalar_lgl_get(r_lst_get(params, 1));
-  bool complete = r_scalar_lgl_get(r_lst_get(params, 2));
-  int out_size = r_scalar_int_get(r_lst_get(params, 3));
+  int type = r_scalar_int_get(type_);
+  bool constrain = r_scalar_lgl_get(constrain_);
+  int size = r_scalar_int_get(size_);
+  bool complete = r_scalar_lgl_get(complete_);
 
   int force = compute_force(type);
 
@@ -64,7 +67,7 @@ SEXP slide_index_common_impl(SEXP x,
 
   SEXP container = PROTECT_N(make_slice_container(type), &n_prot);
 
-  SEXP out = PROTECT_N(vec_init(ptype, out_size), &n_prot);
+  SEXP out = PROTECT_N(vec_init(ptype, size), &n_prot);
   out = PROTECT_N(vec_proxy(out), &n_prot);
 
   for (int i = iteration.min; i < iteration.max; ++i) {
@@ -116,7 +119,7 @@ SEXP slide_index_common_impl(SEXP x,
     UNPROTECT(1);
   }
 
-  out = PROTECT_N(vec_restore(out, ptype, r_int(out_size)), &n_prot);
+  out = PROTECT_N(vec_restore(out, ptype, size_), &n_prot);
   out = PROTECT_N(copy_names(out, x, type), &n_prot);
 
   UNPROTECT(n_prot);

--- a/src/slide-between.h
+++ b/src/slide-between.h
@@ -67,21 +67,16 @@ struct index_info {
 struct range_info {
   SEXP starts;
   SEXP stops;
-  SEXP start;
-  SEXP stop;
-  PROTECT_INDEX start_pidx;
-  PROTECT_INDEX stop_pidx;
+  int pos;
   int size;
   bool start_unbounded;
   bool stop_unbounded;
 };
 
-#define PROTECT_RANGE_INFO(range, n) do {                     \
-  PROTECT((range)->starts);                                   \
-  PROTECT((range)->stops);                                    \
-  PROTECT_WITH_INDEX((range)->start, &(range)->start_pidx);   \
-  PROTECT_WITH_INDEX((range)->stop, &(range)->stop_pidx);     \
-  *n += 4;                                                    \
+#define PROTECT_RANGE_INFO(range, n) do { \
+  PROTECT((range)->starts);               \
+  PROTECT((range)->stops);                \
+  *n += 2;                                \
 } while (0)
 
 // -----------------------------------------------------------------------------

--- a/src/slide-between.h
+++ b/src/slide-between.h
@@ -8,7 +8,6 @@
 
 struct out_info {
   SEXP data;
-  PROTECT_INDEX data_pidx;
   SEXP ptype;
   int size;
   SEXP indices;
@@ -18,12 +17,12 @@ struct out_info {
   int index_size;
 };
 
-#define PROTECT_OUT_INFO(out, n) do {                  \
-  PROTECT_WITH_INDEX((out)->data, &(out)->data_pidx);  \
-  PROTECT((out)->ptype);                               \
-  PROTECT((out)->indices);                             \
-  PROTECT((out)->index);                               \
-  *n += 4;                                             \
+#define PROTECT_OUT_INFO(out, n) do { \
+  PROTECT((out)->data);               \
+  PROTECT((out)->ptype);              \
+  PROTECT((out)->indices);            \
+  PROTECT((out)->index);              \
+  *n += 4;                            \
 } while (0)
 
 // -----------------------------------------------------------------------------

--- a/src/slide-between.h
+++ b/src/slide-between.h
@@ -50,6 +50,8 @@ struct window_info {
 struct index_info {
   SEXP data;
   int size;
+  int current_start_pos;
+  int current_stop_pos;
   slide_compare_fn_t compare_lt;
   slide_compare_fn_t compare_gt;
   slide_compare_fn_t compare_lte;
@@ -58,30 +60,6 @@ struct index_info {
 #define PROTECT_INDEX_INFO(index, n) do {  \
   PROTECT((index)->data);                  \
   *n += 1;                                 \
-} while (0)
-
-// -----------------------------------------------------------------------------
-
-struct last_info {
-  SEXP start_loc;
-  SEXP stop_loc;
-  int* p_start_loc_val;
-  int* p_stop_loc_val;
-  SEXP start_index;
-  SEXP stop_index;
-  SEXP* p_start_index;
-  SEXP* p_stop_index;
-};
-
-#define PROTECT_LAST_INFO(last, n) do {                \
-  PROTECT((last)->start_loc);                          \
-  PROTECT((last)->stop_loc);                           \
-  PROTECT((last)->start_index);                        \
-  PROTECT((last)->stop_index);                         \
-  /* SEXP* assignment must be done after protection */ \
-  (last)->p_start_index = &(last)->start_index;        \
-  (last)->p_stop_index = &(last)->stop_index;          \
-  *n += 4;                                             \
 } while (0)
 
 // -----------------------------------------------------------------------------

--- a/src/slide-between.h
+++ b/src/slide-between.h
@@ -49,8 +49,6 @@ struct window_info {
 
 struct index_info {
   SEXP data;
-  SEXP first;
-  SEXP last;
   int size;
   slide_compare_fn_t compare_lt;
   slide_compare_fn_t compare_gt;
@@ -59,9 +57,7 @@ struct index_info {
 
 #define PROTECT_INDEX_INFO(index, n) do {  \
   PROTECT((index)->data);                  \
-  PROTECT((index)->first);                 \
-  PROTECT((index)->last);                  \
-  *n += 3;                                 \
+  *n += 1;                                 \
 } while (0)
 
 // -----------------------------------------------------------------------------

--- a/src/slide-between.h
+++ b/src/slide-between.h
@@ -71,7 +71,7 @@ struct range_info {
   SEXP stop;
   PROTECT_INDEX start_pidx;
   PROTECT_INDEX stop_pidx;
-  int count;
+  int size;
   bool start_unbounded;
   bool stop_unbounded;
 };

--- a/src/slide-between.h
+++ b/src/slide-between.h
@@ -6,25 +6,6 @@
 
 // -----------------------------------------------------------------------------
 
-struct out_info {
-  SEXP data;
-  int size;
-  SEXP indices;
-  bool has_indices;
-  SEXP index;
-  int* p_index_val;
-  int index_size;
-};
-
-#define PROTECT_OUT_INFO(out, n) do { \
-  PROTECT((out)->data);               \
-  PROTECT((out)->indices);            \
-  PROTECT((out)->index);              \
-  *n += 3;                            \
-} while (0)
-
-// -----------------------------------------------------------------------------
-
 struct window_info {
   int* starts;
   int* stops;

--- a/src/slide-between.h
+++ b/src/slide-between.h
@@ -8,7 +8,6 @@
 
 struct out_info {
   SEXP data;
-  SEXP ptype;
   int size;
   SEXP indices;
   bool has_indices;
@@ -19,10 +18,9 @@ struct out_info {
 
 #define PROTECT_OUT_INFO(out, n) do { \
   PROTECT((out)->data);               \
-  PROTECT((out)->ptype);              \
   PROTECT((out)->indices);            \
   PROTECT((out)->index);              \
-  *n += 4;                            \
+  *n += 3;                            \
 } while (0)
 
 // -----------------------------------------------------------------------------

--- a/src/slide-between.h
+++ b/src/slide-between.h
@@ -31,13 +31,10 @@ struct out_info {
 struct window_info {
   int* starts;
   int* stops;
-  int start;
-  int stop;
-  int start_idx;
-  int stop_idx;
+  int starts_pos;
+  int stops_pos;
   SEXP seq;
   int* p_seq_val;
-  int size;
 };
 
 #define PROTECT_WINDOW_INFO(window, n) do {  \

--- a/src/slide-between.h
+++ b/src/slide-between.h
@@ -50,6 +50,7 @@ struct window_info {
 struct index_info {
   SEXP data;
   int size;
+  int last_pos;
   int current_start_pos;
   int current_stop_pos;
   slide_compare_fn_t compare_lt;
@@ -67,7 +68,6 @@ struct index_info {
 struct range_info {
   SEXP starts;
   SEXP stops;
-  int pos;
   int size;
   bool start_unbounded;
   bool stop_unbounded;
@@ -82,15 +82,9 @@ struct range_info {
 // -----------------------------------------------------------------------------
 
 struct iteration_info {
-  SEXP data;
-  int* p_data_val;
+  int min;
   int max;
 };
-
-#define PROTECT_ITERATION_INFO(iteration, n) do {  \
-  PROTECT((iteration)->data);                      \
-  *n += 1;                                         \
-} while (0)
 
 // -----------------------------------------------------------------------------
 

--- a/src/slide.c
+++ b/src/slide.c
@@ -40,15 +40,24 @@ SEXP slide_common_impl(SEXP x,
   check_before_negativeness(before, after, before_positive, after_unbounded);
   check_after_negativeness(after, before, after_positive, before_unbounded);
 
-  // 1 based for usage as the index in `vec_assign()`
-  SEXP iteration = PROTECT(r_int(1));
-  int* p_iteration_val = INTEGER(iteration);
+  // 1 based index for `vec_assign()`
+  SEXP index;
+  int* p_index;
+
+  if (constrain) {
+    index = PROTECT(r_int(0));
+    p_index = INTEGER(index);
+  } else {
+    index = PROTECT(R_NilValue);
+  }
+
+  int iteration_min = 0;
   int iteration_max = size;
 
   // Iteration adjustment
   if (complete) {
     if (before_positive) {
-      *p_iteration_val += before;
+      iteration_min += before;
     }
     if (after_positive) {
       iteration_max -= after;
@@ -58,7 +67,7 @@ SEXP slide_common_impl(SEXP x,
       iteration_max -= abs(before);
     }
     if (!after_positive) {
-      *p_iteration_val += abs(after);
+      iteration_min += abs(after);
     }
   }
 
@@ -117,11 +126,8 @@ SEXP slide_common_impl(SEXP x,
   int window_stop;
   int window_size;
 
-  for (;
-       *p_iteration_val <= iteration_max;
-       *p_iteration_val += step, start += start_step, stop += stop_step) {
-
-    if (*p_iteration_val % 1024 == 0) {
+  for (int i = iteration_min; i < iteration_max; i += step, start += start_step, stop += stop_step) {
+    if (i % 1024 == 0) {
       R_CheckUserInterrupt();
     }
 
@@ -150,12 +156,14 @@ SEXP slide_common_impl(SEXP x,
       REPROTECT(elt, elt_prot_idx);
 
       if (vec_size(elt) != 1) {
-        stop_not_all_size_one(*p_iteration_val, vec_size(elt));
+        stop_not_all_size_one(i + 1, vec_size(elt));
       }
 
-      vec_assign_impl(out, iteration, elt, false);
+      *p_index = i + 1;
+
+      vec_assign_impl(out, index, elt, false);
     } else {
-      SET_VECTOR_ELT(out, *p_iteration_val - 1, elt);
+      SET_VECTOR_ELT(out, i, elt);
     }
   }
 

--- a/src/slide.c
+++ b/src/slide.c
@@ -112,7 +112,7 @@ SEXP slide_common_impl(SEXP x,
 
   // The indices to slice x with
   SEXP window = PROTECT(compact_seq(0, 0, true));
-  int* p_window_val = INTEGER(window);
+  int* p_window = INTEGER(window);
 
   // The result of each function call
   PROTECT_INDEX elt_prot_idx;
@@ -135,7 +135,7 @@ SEXP slide_common_impl(SEXP x,
     window_stop = min(stop, size - 1);
     window_size = window_stop - window_start + 1;
 
-    init_compact_seq(p_window_val, window_start, window_size, true);
+    init_compact_seq(p_window, window_start, window_size, true);
 
     slice_and_update_env(x, window, env, type, container);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,8 @@
 
 #include "slide.h"
 
+#define PROTECT_N(x, n) (++*n, PROTECT(x))
+
 #define r_int Rf_ScalarInteger
 
 static inline int min(int x, int y) {


### PR DESCRIPTION
Rewrote the guts of `slide_index()` and `slide_between()`. The main improvements are that:

- Many of the structs have been removed in favor of simpler implementations
- The biggest benefit is that we no longer call `vec_slice_impl()` when we do any window updating. This really hurt performance with all of the allocations.

Before

``` r
library(slide)

x <- 1:1e5 + 0L
y <- x - 10L

bench::mark(
  slide(x, identity, .before = 10L),
  slide_index(x, x, identity, .before = 10L),
  slide_between(x, x, identity, .starts = y, .stops = x),
  iterations = 100
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 3 x 6
#>   expression                                                 min  median
#>   <bch:expr>                                             <bch:t> <bch:t>
#> 1 slide(x, identity, .before = 10L)                       42.6ms  50.7ms
#> 2 slide_index(x, x, identity, .before = 10L)             103.1ms 127.9ms
#> 3 slide_between(x, x, identity, .starts = y, .stops = x) 100.8ms 127.2ms
#> # … with 3 more variables: `itr/sec` <dbl>, mem_alloc <bch:byt>,
#> #   `gc/sec` <dbl>
```

<sup>Created on 2019-11-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>

After

```r
library(slide)

x <- 1:1e5 + 0L
y <- x - 10L

bench::mark(
  slide(x, identity, .before = 10L),
  slide_index(x, x, identity, .before = 10L),
  slide_between(x, x, identity, .starts = y, .stops = x),
  iterations = 100
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 3 x 6
#>   expression                                                min median
#>   <bch:expr>                                             <bch:> <bch:>
#> 1 slide(x, identity, .before = 10L)                      39.9ms 47.5ms
#> 2 slide_index(x, x, identity, .before = 10L)             63.3ms 74.6ms
#> 3 slide_between(x, x, identity, .starts = y, .stops = x) 63.1ms 74.5ms
#> # … with 3 more variables: `itr/sec` <dbl>, mem_alloc <bch:byt>,
#> #   `gc/sec` <dbl>
```