### PR TITLE
Default `.ptype` to `NULL` in `_vec()` functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R:
       person(given = "RStudio",
              role = "cph"))
 Description: Provides type-stable rolling window functions over
-    any R data type.  Cumulative and expanding windows are also supported.
+    any R data type. Cumulative and expanding windows are also supported.
     For more advanced usage, an index can be used as a secondary vector
     that defines how sliding windows are to be created.
 License: MIT + file LICENSE
@@ -47,6 +47,7 @@ Collate:
     'hop-index2.R'
     'hop.R'
     'hop2.R'
+    'names.R'
     'phop-index.R'
     'phop.R'
     'slide-index2.R'

--- a/R/hop-index.R
+++ b/R/hop-index.R
@@ -112,7 +112,7 @@ hop_index_vec <- function(.x,
                           .stops,
                           .f,
                           ...,
-                          .ptype = list()) {
+                          .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- hop_index_vec_simplify(

--- a/R/hop-index.R
+++ b/R/hop-index.R
@@ -156,7 +156,7 @@ hop_index_vec_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname hop_index

--- a/R/hop-index2.R
+++ b/R/hop-index2.R
@@ -88,7 +88,7 @@ hop_index2_vec <- function(.x,
                            .stops,
                            .f,
                            ...,
-                           .ptype = list()) {
+                           .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- hop_index2_vec_simplify(

--- a/R/hop-index2.R
+++ b/R/hop-index2.R
@@ -136,7 +136,7 @@ hop_index2_vec_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname hop_index2

--- a/R/hop.R
+++ b/R/hop.R
@@ -154,7 +154,7 @@ hop_vec_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname hop

--- a/R/hop.R
+++ b/R/hop.R
@@ -114,7 +114,7 @@ hop_vec <- function(.x,
                     .stops,
                     .f,
                     ...,
-                    .ptype = list()) {
+                    .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- hop_vec_simplify(

--- a/R/hop2.R
+++ b/R/hop2.R
@@ -83,7 +83,7 @@ hop2_vec <- function(.x,
                      .stops,
                      .f,
                      ...,
-                     .ptype = list()) {
+                     .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- hop2_vec_simplify(

--- a/R/hop2.R
+++ b/R/hop2.R
@@ -127,7 +127,7 @@ hop2_vec_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname hop2

--- a/R/names.R
+++ b/R/names.R
@@ -1,0 +1,10 @@
+# vctrs doesn't publicly export these, but we can get
+# them through the C API
+
+vec_set_names <- function(x, names) {
+  .Call(slide_vec_set_names, x, names)
+}
+
+vec_names <- function(x) {
+  .Call(slide_vec_names, x)
+}

--- a/R/phop-index.R
+++ b/R/phop-index.R
@@ -71,7 +71,7 @@ phop_index_simplify <- function(.l,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname hop_index2

--- a/R/phop-index.R
+++ b/R/phop-index.R
@@ -27,7 +27,7 @@ phop_index_vec <- function(.l,
                            .stops,
                            .f,
                            ...,
-                           .ptype = list()) {
+                           .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- phop_index_simplify(

--- a/R/phop.R
+++ b/R/phop.R
@@ -24,7 +24,7 @@ phop_vec <- function(.l,
                      .stops,
                      .f,
                      ...,
-                     .ptype = list()) {
+                     .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- phop_simplify(

--- a/R/phop.R
+++ b/R/phop.R
@@ -64,7 +64,7 @@ phop_simplify <- function(.l,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname hop2

--- a/R/pslide-index.R
+++ b/R/pslide-index.R
@@ -78,7 +78,7 @@ pslide_index_simplify <- function(.l,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname slide_index2

--- a/R/pslide-index.R
+++ b/R/pslide-index.R
@@ -30,7 +30,7 @@ pslide_index_vec <- function(.l,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE,
-                             .ptype = list()) {
+                             .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- pslide_index_simplify(

--- a/R/pslide-period.R
+++ b/R/pslide-period.R
@@ -99,7 +99,7 @@ pslide_period_vec_simplify <- function(.l,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname slide_period2

--- a/R/pslide-period.R
+++ b/R/pslide-period.R
@@ -39,7 +39,7 @@ pslide_period_vec <- function(.l,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE,
-                              .ptype = list()) {
+                              .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- pslide_period_vec_simplify(

--- a/R/pslide.R
+++ b/R/pslide.R
@@ -30,7 +30,7 @@ pslide_vec <- function(.l,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE,
-                       .ptype = list()) {
+                       .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- pslide_vec_simplify(

--- a/R/pslide.R
+++ b/R/pslide.R
@@ -78,7 +78,7 @@ pslide_vec_simplify <- function(.l,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname slide2

--- a/R/slide-index.R
+++ b/R/slide-index.R
@@ -188,7 +188,7 @@ slide_index_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname slide_index

--- a/R/slide-index.R
+++ b/R/slide-index.R
@@ -140,7 +140,7 @@ slide_index_vec <- function(.x,
                             .before = 0L,
                             .after = 0L,
                             .complete = FALSE,
-                            .ptype = list()) {
+                            .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- slide_index_simplify(

--- a/R/slide-index2.R
+++ b/R/slide-index2.R
@@ -146,7 +146,7 @@ slide_index2_vec_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname slide_index2

--- a/R/slide-index2.R
+++ b/R/slide-index2.R
@@ -94,7 +94,7 @@ slide_index2_vec <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE,
-                             .ptype = list()) {
+                             .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- slide_index2_vec_simplify(

--- a/R/slide-period.R
+++ b/R/slide-period.R
@@ -136,7 +136,7 @@ slide_period_vec <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE,
-                             .ptype = list()) {
+                             .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- slide_period_simplify(

--- a/R/slide-period.R
+++ b/R/slide-period.R
@@ -196,7 +196,7 @@ slide_period_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname slide_period

--- a/R/slide-period2.R
+++ b/R/slide-period2.R
@@ -174,7 +174,7 @@ slide_period2_vec_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname slide_period2

--- a/R/slide-period2.R
+++ b/R/slide-period2.R
@@ -110,7 +110,7 @@ slide_period2_vec <- function(.x,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE,
-                              .ptype = list()) {
+                              .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- slide_period2_vec_simplify(

--- a/R/slide.R
+++ b/R/slide.R
@@ -31,10 +31,18 @@
 #'   Should `.f` be evaluated on complete windows only? If `FALSE`,
 #'   the default, then partial computations will be allowed.
 #'
-#' @param .ptype `[vector(0)]`
+#' @param .ptype `[vector(0) / NULL]`
 #'
-#'   The prototype corresponding to the type of the output. Defaults to
-#'   a `list()`.
+#'   A prototype corresponding to the type of the output.
+#'
+#'   If `NULL`, the default, the output type is determined by computing the
+#'   common type across the results of the calls to `.f`.
+#'
+#'   If supplied, the result of each call to `.f` will be cast to that type,
+#'   and the final output will have that type.
+#'
+#'   If `getOption("vctrs.no_guessing")` is `TRUE`, the `.ptype` must be
+#'   supplied. This is a way to make production code demand fixed types.
 #'
 #' @template param-before-after-slide
 #'
@@ -212,7 +220,7 @@ slide_vec <- function(.x,
                       .after = 0L,
                       .step = 1L,
                       .complete = FALSE,
-                      .ptype = list()) {
+                      .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- slide_vec_simplify(

--- a/R/slide.R
+++ b/R/slide.R
@@ -260,7 +260,7 @@ slide_vec_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname slide

--- a/R/slide2.R
+++ b/R/slide2.R
@@ -159,7 +159,7 @@ slide2_vec_simplify <- function(.x,
 
   check_all_size_one(out)
 
-  vec_c(!!!out)
+  vec_simplify(out)
 }
 
 #' @rdname slide2

--- a/R/slide2.R
+++ b/R/slide2.R
@@ -107,7 +107,7 @@ slide2_vec <- function(.x,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE,
-                       .ptype = list()) {
+                       .ptype = NULL) {
 
   if (is.null(.ptype)) {
     out <- slide2_vec_simplify(

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,3 +92,21 @@ compute_size <- function(x, type) {
     vec_size(x[[1L]])
   }
 }
+
+# Ensures that `slide_vec(c(x = 1), ~.x, .ptype = NULL)` works, and keeps it
+# in line with what `map_dbl(c(x = 1), ~c(y = 2))` does by only keeping names
+# from `x`
+vec_simplify <- function(x) {
+  names <- vec_names(x)
+
+  if (is.null(names)) {
+    out <- vec_c(!!!x)
+    return(out)
+  }
+
+  x <- vec_set_names(x, NULL)
+
+  out <- vec_c(!!!x)
+
+  vec_set_names(out, names)
+}

--- a/man/hop.Rd
+++ b/man/hop.Rd
@@ -13,7 +13,7 @@
 \usage{
 hop(.x, .starts, .stops, .f, ...)
 
-hop_vec(.x, .starts, .stops, .f, ..., .ptype = list())
+hop_vec(.x, .starts, .stops, .f, ..., .ptype = NULL)
 
 hop_dbl(.x, .starts, .stops, .f, ...)
 
@@ -71,10 +71,18 @@ This syntax allows you to create very compact anonymous functions.}
 
 \item{...}{Additional arguments passed on to the mapped function.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/man/hop2.Rd
+++ b/man/hop2.Rd
@@ -21,7 +21,7 @@
 \usage{
 hop2(.x, .y, .starts, .stops, .f, ...)
 
-hop2_vec(.x, .y, .starts, .stops, .f, ..., .ptype = list())
+hop2_vec(.x, .y, .starts, .stops, .f, ..., .ptype = NULL)
 
 hop2_dbl(.x, .y, .starts, .stops, .f, ...)
 
@@ -55,7 +55,7 @@ hop2_dfc(
 
 phop(.l, .starts, .stops, .f, ...)
 
-phop_vec(.l, .starts, .stops, .f, ..., .ptype = list())
+phop_vec(.l, .starts, .stops, .f, ..., .ptype = NULL)
 
 phop_dbl(.l, .starts, .stops, .f, ...)
 
@@ -113,10 +113,18 @@ This syntax allows you to create very compact anonymous functions.}
 
 \item{...}{Additional arguments passed on to the mapped function.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/man/hop_index.Rd
+++ b/man/hop_index.Rd
@@ -13,7 +13,7 @@
 \usage{
 hop_index(.x, .i, .starts, .stops, .f, ...)
 
-hop_index_vec(.x, .i, .starts, .stops, .f, ..., .ptype = list())
+hop_index_vec(.x, .i, .starts, .stops, .f, ..., .ptype = NULL)
 
 hop_index_dbl(.x, .i, .starts, .stops, .f, ...)
 
@@ -91,10 +91,18 @@ This syntax allows you to create very compact anonymous functions.}
 
 \item{...}{Additional arguments passed on to the mapped function.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/man/hop_index2.Rd
+++ b/man/hop_index2.Rd
@@ -21,7 +21,7 @@
 \usage{
 hop_index2(.x, .y, .i, .starts, .stops, .f, ...)
 
-hop_index2_vec(.x, .y, .i, .starts, .stops, .f, ..., .ptype = list())
+hop_index2_vec(.x, .y, .i, .starts, .stops, .f, ..., .ptype = NULL)
 
 hop_index2_dbl(.x, .y, .i, .starts, .stops, .f, ...)
 
@@ -57,7 +57,7 @@ hop_index2_dfc(
 
 phop_index(.l, .i, .starts, .stops, .f, ...)
 
-phop_index_vec(.l, .i, .starts, .stops, .f, ..., .ptype = list())
+phop_index_vec(.l, .i, .starts, .stops, .f, ..., .ptype = NULL)
 
 phop_index_dbl(.l, .i, .starts, .stops, .f, ...)
 
@@ -135,10 +135,18 @@ This syntax allows you to create very compact anonymous functions.}
 
 \item{...}{Additional arguments passed on to the mapped function.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/man/slide-package.Rd
+++ b/man/slide-package.Rd
@@ -6,10 +6,10 @@
 \alias{_PACKAGE}
 \title{slide: Sliding Window Functions}
 \description{
-Provides type stable rolling window functions over any R data type.
-    Cumulative and expanding windows are also supported. For more advanced
-    usage, an index can be used as a secondary vector that defines how
-    sliding windows are to be created.
+Provides type-stable rolling window functions over
+    any R data type. Cumulative and expanding windows are also supported.
+    For more advanced usage, an index can be used as a secondary vector
+    that defines how sliding windows are to be created.
 }
 \seealso{
 Useful links:

--- a/man/slide.Rd
+++ b/man/slide.Rd
@@ -21,7 +21,7 @@ slide_vec(
   .after = 0L,
   .step = 1L,
   .complete = FALSE,
-  .ptype = list()
+  .ptype = NULL
 )
 
 slide_dbl(
@@ -126,10 +126,18 @@ The number of elements to shift the window forward between function calls.}
 Should \code{.f} be evaluated on complete windows only? If \code{FALSE},
 the default, then partial computations will be allowed.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/man/slide2.Rd
+++ b/man/slide2.Rd
@@ -39,7 +39,7 @@ slide2_vec(
   .after = 0L,
   .step = 1L,
   .complete = FALSE,
-  .ptype = list()
+  .ptype = NULL
 )
 
 slide2_dbl(
@@ -122,7 +122,7 @@ pslide_vec(
   .after = 0L,
   .step = 1L,
   .complete = FALSE,
-  .ptype = list()
+  .ptype = NULL
 )
 
 pslide_dbl(
@@ -227,10 +227,18 @@ The number of elements to shift the window forward between function calls.}
 Should \code{.f} be evaluated on complete windows only? If \code{FALSE},
 the default, then partial computations will be allowed.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/man/slide_index.Rd
+++ b/man/slide_index.Rd
@@ -21,7 +21,7 @@ slide_index_vec(
   .before = 0L,
   .after = 0L,
   .complete = FALSE,
-  .ptype = list()
+  .ptype = NULL
 )
 
 slide_index_dbl(.x, .i, .f, ..., .before = 0L, .after = 0L, .complete = FALSE)
@@ -112,10 +112,18 @@ have the same 3 restrictions as \code{.i} itself.}
 Should \code{.f} be evaluated on complete windows only? If \code{FALSE},
 the default, then partial computations will be allowed.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/man/slide_index2.Rd
+++ b/man/slide_index2.Rd
@@ -30,7 +30,7 @@ slide_index2_vec(
   .before = 0L,
   .after = 0L,
   .complete = FALSE,
-  .ptype = list()
+  .ptype = NULL
 )
 
 slide_index2_dbl(
@@ -113,7 +113,7 @@ pslide_index_vec(
   .before = 0L,
   .after = 0L,
   .complete = FALSE,
-  .ptype = list()
+  .ptype = NULL
 )
 
 pslide_index_dbl(.l, .i, .f, ..., .before = 0L, .after = 0L, .complete = FALSE)
@@ -204,10 +204,18 @@ have the same 3 restrictions as \code{.i} itself.}
 Should \code{.f} be evaluated on complete windows only? If \code{FALSE},
 the default, then partial computations will be allowed.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/man/slide_period.Rd
+++ b/man/slide_period.Rd
@@ -35,7 +35,7 @@ slide_period_vec(
   .before = 0L,
   .after = 0L,
   .complete = FALSE,
-  .ptype = list()
+  .ptype = NULL
 )
 
 slide_period_dbl(
@@ -193,10 +193,18 @@ allows you to "look forward" from the current element if used as the
 Should \code{.f} be evaluated on complete windows only? If \code{FALSE},
 the default, then partial computations will be allowed.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/man/slide_period2.Rd
+++ b/man/slide_period2.Rd
@@ -45,7 +45,7 @@ slide_period2_vec(
   .before = 0L,
   .after = 0L,
   .complete = FALSE,
-  .ptype = list()
+  .ptype = NULL
 )
 
 slide_period2_dbl(
@@ -160,7 +160,7 @@ pslide_period_vec(
   .before = 0L,
   .after = 0L,
   .complete = FALSE,
-  .ptype = list()
+  .ptype = NULL
 )
 
 pslide_period_dbl(
@@ -326,10 +326,18 @@ allows you to "look forward" from the current element if used as the
 Should \code{.f} be evaluated on complete windows only? If \code{FALSE},
 the default, then partial computations will be allowed.}
 
-\item{.ptype}{\verb{[vector(0)]}
+\item{.ptype}{\verb{[vector(0) / NULL]}
 
-The prototype corresponding to the type of the output. Defaults to
-a \code{list()}.}
+A prototype corresponding to the type of the output.
+
+If \code{NULL}, the default, the output type is determined by computing the
+common type across the results of the calls to \code{.f}.
+
+If supplied, the result of each call to \code{.f} will be cast to that type,
+and the final output will have that type.
+
+If \code{getOption("vctrs.no_guessing")} is \code{TRUE}, the \code{.ptype} must be
+supplied. This is a way to make production code demand fixed types.}
 
 \item{.names_to}{Optionally, the name of a column where the names
 of \code{...} arguments are copied. These names are useful to identify

--- a/src/init.c
+++ b/src/init.c
@@ -11,6 +11,8 @@ extern SEXP hop_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP
 extern SEXP slide_block(SEXP, SEXP, SEXP);
 extern SEXP slide_compute_from(SEXP, SEXP, SEXP, SEXP);
 extern SEXP slide_compute_to(SEXP, SEXP, SEXP, SEXP);
+extern SEXP slide_vec_set_names(SEXP, SEXP);
+extern SEXP slide_vec_names(SEXP);
 
 // Defined below
 SEXP slide_init(SEXP);
@@ -23,6 +25,8 @@ static const R_CallMethodDef CallEntries[] = {
   {"slide_block",               (DL_FUNC) &slide_block, 3},
   {"slide_compute_from",        (DL_FUNC) &slide_compute_from, 4},
   {"slide_compute_to",          (DL_FUNC) &slide_compute_to, 4},
+  {"slide_vec_set_names",       (DL_FUNC) &slide_vec_set_names, 2},
+  {"slide_vec_names",           (DL_FUNC) &slide_vec_names, 1},
   {"slide_init",                (DL_FUNC) &slide_init, 1},
   {NULL, NULL, 0}
 };

--- a/src/names.c
+++ b/src/names.c
@@ -1,0 +1,11 @@
+#include <vctrs.h>
+
+// [[ export() ]]
+SEXP slide_vec_set_names(SEXP x, SEXP names) {
+  return vec_set_names(x, names);
+}
+
+// [[ export() ]]
+SEXP slide_vec_names(SEXP x) {
+  return vec_names(x);
+}

--- a/tests/testthat/test-hop-index-vec.R
+++ b/tests/testthat/test-hop-index-vec.R
@@ -10,7 +10,7 @@ test_that("size of each `.f` result must be 1", {
 
 test_that("inner type is allowed to be different", {
   expect_equal(
-    hop_index_vec(1:2, 1:2, 1:2, 1:2, ~if (.x == 1L) {1} else {"hi"}),
+    hop_index_vec(1:2, 1:2, 1:2, 1:2, ~if (.x == 1L) {1} else {"hi"}, .ptype = list()),
     list(1, "hi")
   )
 })
@@ -26,7 +26,7 @@ test_that("inner type can be restricted with list_of", {
 # .ptype
 
 test_that(".ptype is respected", {
-  expect_equal(hop_index_vec(1, 1, 1, 1, ~.x), list(1))
+  expect_equal(hop_index_vec(1, 1, 1, 1, ~.x), 1)
   expect_equal(hop_index_vec(1, 1, 1, 1, ~.x, .ptype = int()), 1L)
   expect_equal(hop_index_vec(1, 1, 1, 1, ~.x, .ptype = new_date()), as.Date("1970-01-02"))
   expect_error(hop_index_vec(1, 1, 1, 1, ~.x + .5, .ptype = integer()), class = "vctrs_error_cast_lossy")

--- a/tests/testthat/test-hop-index2-vec.R
+++ b/tests/testthat/test-hop-index2-vec.R
@@ -2,11 +2,11 @@
 # hop_index2_vec
 
 test_that("hop_index2_vec() works", {
-  expect_equivalent(hop_index2_vec(1L, 1L, 1, 1, 1, ~.x + .y), list(2L))
+  expect_equivalent(hop_index2_vec(1L, 1L, 1, 1, 1, ~.x + .y), 2L)
 })
 
 test_that("hop_index2_vec() retains names of x", {
-  expect_equivalent(hop_index2_vec(c(x = 1L), c(y = 1L), 1,  1, 1, ~.x + .y), list(x = 2L))
+  expect_equivalent(hop_index2_vec(c(x = 1L), c(y = 1L), 1,  1, 1, ~.x + .y), c(x = 2L))
 })
 
 test_that("hop_index2_vec() can simplify automatically", {

--- a/tests/testthat/test-hop-vec.R
+++ b/tests/testthat/test-hop-vec.R
@@ -10,7 +10,7 @@ test_that("size of each `.f` result must be 1", {
 
 test_that("inner type is allowed to be different", {
   expect_equal(
-    hop_vec(1:2, 1:2, 1:2, ~if (.x == 1L) {1} else {"hi"}),
+    hop_vec(1:2, 1:2, 1:2, ~if (.x == 1L) {1} else {"hi"}, .ptype = list()),
     list(1, "hi")
   )
 })
@@ -26,7 +26,7 @@ test_that("inner type can be restricted with list_of", {
 # .ptype
 
 test_that(".ptype is respected", {
-  expect_equal(hop_vec(1, 1, 1, ~.x), list(1))
+  expect_equal(hop_vec(1, 1, 1, ~.x), 1)
   expect_equal(hop_vec(1, 1, 1, ~.x, .ptype = int()), 1L)
   expect_equal(hop_vec(1, 1, 1, ~.x, .ptype = new_date()), as.Date("1970-01-02"))
   expect_error(hop_vec(1, 1, 1, ~.x + .5, .ptype = integer()), class = "vctrs_error_cast_lossy")

--- a/tests/testthat/test-hop2-vec.R
+++ b/tests/testthat/test-hop2-vec.R
@@ -2,11 +2,11 @@
 # hop2_vec
 
 test_that("hop2_vec() works", {
-  expect_equivalent(hop2_vec(1L, 1L, 1, 1, ~.x + .y), list(2L))
+  expect_equivalent(hop2_vec(1L, 1L, 1, 1, ~.x + .y), 2L)
 })
 
 test_that("hop2_vec() retains names of x", {
-  expect_equivalent(hop2_vec(c(x = 1L), c(y = 1L), 1, 1, ~.x + .y), list(x = 2L))
+  expect_equivalent(hop2_vec(c(x = 1L), c(y = 1L), 1, 1, ~.x + .y), c(x = 2L))
 })
 
 test_that("hop2_vec() can simplify automatically", {

--- a/tests/testthat/test-phop-index-vec.R
+++ b/tests/testthat/test-phop-index-vec.R
@@ -2,11 +2,11 @@
 # phop_index_vec
 
 test_that("phop_index_vec() works", {
-  expect_equivalent(phop_index_vec(list(1L, 1L), 1, 1, 1, ~.x + .y), list(2L))
+  expect_equivalent(phop_index_vec(list(1L, 1L), 1, 1, 1, ~.x + .y), 2L)
 })
 
 test_that("phop_index_vec() retains names of first input", {
-  expect_equivalent(phop_index_vec(list(c(x = 1L), c(y = 1L)), 1, 1, 1, ~.x + .y), list(x = 2L))
+  expect_equivalent(phop_index_vec(list(c(x = 1L), c(y = 1L)), 1, 1, 1, ~.x + .y), c(x = 2L))
 })
 
 test_that("phop_index_vec() can simplify automatically", {
@@ -22,7 +22,8 @@ test_that("phop_index_vec() errors if it can't simplify", {
 })
 
 test_that("completely empty input returns ptype", {
-  expect_equal(phop_index_vec(list(), integer(), integer(), integer(), ~.x), list())
+  expect_equal(phop_index_vec(list(), integer(), integer(), integer(), ~.x), NULL)
+  expect_equal(phop_index_vec(list(), integer(), integer(), integer(), ~.x, .ptype = list()), list())
   expect_equal(phop_index_vec(list(), integer(), integer(), integer(), ~.x, .ptype = int()), int())
 })
 

--- a/tests/testthat/test-phop-vec.R
+++ b/tests/testthat/test-phop-vec.R
@@ -2,11 +2,11 @@
 # phop_vec
 
 test_that("phop_vec() works", {
-  expect_equivalent(phop_vec(list(1L, 1L), 1, 1, ~.x + .y), list(2L))
+  expect_equivalent(phop_vec(list(1L, 1L), 1, 1, ~.x + .y), 2L)
 })
 
 test_that("phop_vec() retains names of first input", {
-  expect_equivalent(phop_vec(list(c(x = 1L), c(y = 1L)), 1, 1, ~.x + .y), list(x = 2L))
+  expect_equivalent(phop_vec(list(c(x = 1L), c(y = 1L)), 1, 1, ~.x + .y), c(x = 2L))
 })
 
 test_that("phop_vec() can simplify automatically", {

--- a/tests/testthat/test-pslide-index-vec.R
+++ b/tests/testthat/test-pslide-index-vec.R
@@ -2,11 +2,11 @@
 # pslide_index_vec
 
 test_that("pslide_index_vec() works", {
-  expect_equivalent(pslide_index_vec(list(1L, 1L), 1, ~.x + .y), list(2L))
+  expect_equivalent(pslide_index_vec(list(1L, 1L), 1, ~.x + .y), 2L)
 })
 
 test_that("pslide_index_vec() retains names of first input", {
-  expect_equivalent(pslide_index_vec(list(c(x = 1L), c(y = 1L)), 1, ~.x + .y), list(x = 2L))
+  expect_equivalent(pslide_index_vec(list(c(x = 1L), c(y = 1L)), 1, ~.x + .y), c(x = 2L))
 })
 
 test_that("pslide_index_vec() can simplify automatically", {
@@ -22,7 +22,8 @@ test_that("pslide_index_vec() errors if it can't simplify", {
 })
 
 test_that("completely empty input returns ptype", {
-  expect_equal(pslide_index_vec(list(), integer(), ~.x), list())
+  expect_equal(pslide_index_vec(list(), integer(), ~.x), NULL)
+  expect_equal(pslide_index_vec(list(), integer(), ~.x, .ptype = list()), list())
   expect_equal(pslide_index_vec(list(), integer(), ~.x, .ptype = int()), int())
 })
 

--- a/tests/testthat/test-pslide-period-vec.R
+++ b/tests/testthat/test-pslide-period-vec.R
@@ -10,7 +10,7 @@ test_that("size of each `.f` result must be 1", {
 
 test_that("inner type is allowed to be different", {
   expect_equal(
-    pslide_period_vec(list(1:2, 1:2), new_date(1:2), "day", ~if (.x == 1L) {1} else {"hi"}),
+    pslide_period_vec(list(1:2, 1:2), new_date(1:2), "day", ~if (.x == 1L) {1} else {"hi"}, .ptype = list()),
     list(1, "hi")
   )
 })
@@ -26,7 +26,7 @@ test_that("inner type can be restricted with list_of", {
 # .ptype
 
 test_that(".ptype is respected", {
-  expect_equal(pslide_period_vec(list(1, 1), new_date(0), "day", ~.x), list(1))
+  expect_equal(pslide_period_vec(list(1, 1), new_date(0), "day", ~.x), 1)
   expect_equal(pslide_period_vec(list(1, 1), new_date(0), "day", ~.x, .ptype = int()), 1L)
   expect_equal(pslide_period_vec(list(1, 1), new_date(0), "day", ~.x, .ptype = new_date()), as.Date("1970-01-02"))
   expect_error(pslide_period_vec(list(1, 1), new_date(0), "day", ~.x + .5, .ptype = integer()), class = "vctrs_error_cast_lossy")

--- a/tests/testthat/test-pslide-vec.R
+++ b/tests/testthat/test-pslide-vec.R
@@ -2,11 +2,11 @@
 # pslide_vec
 
 test_that("pslide_vec() works", {
-  expect_equivalent(pslide_vec(list(1L, 1L), ~.x + .y), list(2L))
+  expect_equivalent(pslide_vec(list(1L, 1L), ~.x + .y), 2L)
 })
 
 test_that("pslide_vec() retains names of first input", {
-  expect_equivalent(pslide_vec(list(c(x = 1L), c(y = 1L)), ~.x + .y), list(x = 2L))
+  expect_equivalent(pslide_vec(list(c(x = 1L), c(y = 1L)), ~.x + .y), c(x = 2L))
 })
 
 test_that("pslide_vec() can simplify automatically", {

--- a/tests/testthat/test-slide-index-vec.R
+++ b/tests/testthat/test-slide-index-vec.R
@@ -10,7 +10,7 @@ test_that("size of each `.f` result must be 1", {
 
 test_that("inner type is allowed to be different", {
   expect_equal(
-    slide_index_vec(1:2, 1:2, ~if (.x == 1L) {1} else {"hi"}),
+    slide_index_vec(1:2, 1:2, ~if (.x == 1L) {1} else {"hi"}, .ptype = list()),
     list(1, "hi")
   )
 })
@@ -26,7 +26,7 @@ test_that("inner type can be restricted with list_of", {
 # .ptype
 
 test_that(".ptype is respected", {
-  expect_equal(slide_index_vec(1, 1, ~.x), list(1))
+  expect_equal(slide_index_vec(1, 1, ~.x), 1)
   expect_equal(slide_index_vec(1, 1, ~.x, .ptype = int()), 1L)
   expect_equal(slide_index_vec(1, 1, ~.x, .ptype = new_date()), as.Date("1970-01-02"))
   expect_error(slide_index_vec(1, 1, ~.x + .5, .ptype = integer()), class = "vctrs_error_cast_lossy")

--- a/tests/testthat/test-slide-index2-vec.R
+++ b/tests/testthat/test-slide-index2-vec.R
@@ -2,11 +2,11 @@
 # slide_index2_vec
 
 test_that("slide_index2_vec() works", {
-  expect_equivalent(slide_index2_vec(1L, 1L, 1, ~.x + .y), list(2L))
+  expect_equivalent(slide_index2_vec(1L, 1L, 1, ~.x + .y), 2L)
 })
 
 test_that("slide_index2_vec() retains names of x", {
-  expect_equivalent(slide_index2_vec(c(x = 1L), c(y = 1L), 1, ~.x + .y), list(x = 2L))
+  expect_equivalent(slide_index2_vec(c(x = 1L), c(y = 1L), 1, ~.x + .y), c(x = 2L))
 })
 
 test_that("slide_index2_vec() can simplify automatically", {

--- a/tests/testthat/test-slide-period-vec.R
+++ b/tests/testthat/test-slide-period-vec.R
@@ -10,7 +10,7 @@ test_that("size of each `.f` result must be 1", {
 
 test_that("inner type is allowed to be different", {
   expect_equal(
-    slide_period_vec(1:2, new_date(1:2), "day", ~if (.x == 1L) {1} else {"hi"}),
+    slide_period_vec(1:2, new_date(1:2), "day", ~if (.x == 1L) {1} else {"hi"}, .ptype = list()),
     list(1, "hi")
   )
 })
@@ -26,7 +26,7 @@ test_that("inner type can be restricted with list_of", {
 # .ptype
 
 test_that(".ptype is respected", {
-  expect_equal(slide_period_vec(1, new_date(0), "day", ~.x), list(1))
+  expect_equal(slide_period_vec(1, new_date(0), "day", ~.x), 1)
   expect_equal(slide_period_vec(1, new_date(0), "day", ~.x, .ptype = int()), 1L)
   expect_equal(slide_period_vec(1, new_date(0), "day", ~.x, .ptype = new_date()), as.Date("1970-01-02"))
   expect_error(slide_period_vec(1, new_date(0), "day", ~.x + .5, .ptype = integer()), class = "vctrs_error_cast_lossy")

--- a/tests/testthat/test-slide-period2-vec.R
+++ b/tests/testthat/test-slide-period2-vec.R
@@ -10,7 +10,7 @@ test_that("size of each `.f` result must be 1", {
 
 test_that("inner type is allowed to be different", {
   expect_equal(
-    slide_period2_vec(1:2, 1:2, new_date(1:2), "day", ~if (.x == 1L) {1} else {"hi"}),
+    slide_period2_vec(1:2, 1:2, new_date(1:2), "day", ~if (.x == 1L) {1} else {"hi"}, .ptype = list()),
     list(1, "hi")
   )
 })
@@ -26,7 +26,7 @@ test_that("inner type can be restricted with list_of", {
 # .ptype
 
 test_that(".ptype is respected", {
-  expect_equal(slide_period2_vec(1, 1, new_date(0), "day", ~.x), list(1))
+  expect_equal(slide_period2_vec(1, 1, new_date(0), "day", ~.x), 1)
   expect_equal(slide_period2_vec(1, 1, new_date(0), "day", ~.x, .ptype = int()), 1L)
   expect_equal(slide_period2_vec(1, 1, new_date(0), "day", ~.x, .ptype = new_date()), as.Date("1970-01-02"))
   expect_error(slide_period2_vec(1, 1, new_date(0), "day", ~.x + .5, .ptype = integer()), class = "vctrs_error_cast_lossy")

--- a/tests/testthat/test-slide-vec.R
+++ b/tests/testthat/test-slide-vec.R
@@ -10,7 +10,7 @@ test_that("size of each `.f` result must be 1", {
 
 test_that("inner type is allowed to be different", {
   expect_equal(
-    slide_vec(1:2, ~if (.x == 1L) {1} else {"hi"}),
+    slide_vec(1:2, ~if (.x == 1L) {1} else {"hi"}, .ptype = list()),
     list(1, "hi")
   )
 })
@@ -26,7 +26,7 @@ test_that("inner type can be restricted with list_of", {
 # .ptype
 
 test_that(".ptype is respected", {
-  expect_equal(slide_vec(1, ~.x), list(1))
+  expect_equal(slide_vec(1, ~.x), 1)
   expect_equal(slide_vec(1, ~.x, .ptype = int()), 1L)
   expect_equal(slide_vec(1, ~.x, .ptype = new_date()), as.Date("1970-01-02"))
   expect_error(slide_vec(1, ~.x + .5, .ptype = integer()), class = "vctrs_error_cast_lossy")

--- a/tests/testthat/test-slide-vec.R
+++ b/tests/testthat/test-slide-vec.R
@@ -82,6 +82,15 @@ test_that("names can be placed on atomics", {
   expect_equal(names(slide_vec(x, ~.x, .ptype = dbl())), names)
 })
 
+test_that("when simplifying, names from `.x` are kept, and new names from `.f` results are dropped", {
+  x <- set_names(1, "x")
+
+  expect_identical(
+    slide_vec(x, ~c(y = 2), .ptype = NULL),
+    c(x = 2)
+  )
+})
+
 test_that("names are not placed on data frames rownames", {
   names <- letters[1:2]
   x <- set_names(1:2, names)

--- a/tests/testthat/test-slide2-vec.R
+++ b/tests/testthat/test-slide2-vec.R
@@ -2,11 +2,11 @@
 # slide2_vec
 
 test_that("slide2_vec() works", {
-  expect_equivalent(slide2_vec(1L, 1L, ~.x + .y), list(2L))
+  expect_equivalent(slide2_vec(1L, 1L, ~.x + .y), 2L)
 })
 
 test_that("slide2_vec() retains names of x", {
-  expect_equivalent(slide2_vec(c(x = 1L), c(y = 1L), ~.x + .y), list(x = 2L))
+  expect_equivalent(slide2_vec(c(x = 1L), c(y = 1L), ~.x + .y), c(x = 2L))
 })
 
 test_that("slide2_vec() can simplify automatically", {


### PR DESCRIPTION
Closes #54 
Closes #52 

For default auto-simplifying, which seems more useful than `.ptype = list()`.

Also fixes a small bug when simplifying with `_vec(.ptype = NULL)` where names on `.x` compete with names in the output from `.f`, causing a `vec_c()` error requesting name repair. The correct result is always to use names from `.x`, being careful to use `vec_names()` and `vec_set_names()`